### PR TITLE
Fixed a few mixins, changed the way the attributes work, added language file

### DIFF
--- a/src/main/java/de/dafuqs/additionalentityattributes/AdditionalEntityAttributes.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/AdditionalEntityAttributes.java
@@ -12,48 +12,51 @@ public class AdditionalEntityAttributes implements ModInitializer {
 	
 	/**
 	 * for testing, default vanilla commands can be used:
-	 * /attribute Player662 additionalentityattributes:critical_damage_multiplier base get
+	 * /attribute Player662 additionalentityattributes:critical_bonuse_damage base get
 	 * /attribute Player583 additionalentityattributes:lava_visibility base set 10
 	 * /attribute Player583 additionalentityattributes:lava_speed base set 0.5
 	 * /attribute Player556 additionalentityattributes:water_speed base set 0.5
 	 */
 	
 	/**
-	 * Increases the dealt damage when dealing critical hits
-	 * By default, critical hits deal 1.5 times the damage
-	 * Using a multiplier of 0.5 will bump that value up to 2x the damage, for example
+	 * Controls the bonus damage dealt when dealing critical hits
+	 * By default, critical hits deal 1.5 times the damage, so the base value of this attribute is 0.5.
+	 * Adding a flat value of 0.5 will bump that value up to make critical hits deal 2x the damage, for example
+	 * Multiplying this attribute's value with a modifier value of 0.5 will increase the critical hit damage
+	 * by 50%, meaning it will add 50% of the base 50% bonus damage on top, resulting in a critical hit damage
+	 * multiplier of 75% (1.75x damage).
 	 */
-	public static final EntityAttribute CRITICAL_DAMAGE_MULTIPLIER = createAttribute("critical_damage_multiplier", 0.0, 0.0, 1024.0);
+	public static final EntityAttribute CRITICAL_BONUS_DAMAGE = createAttribute("critical_bonus_damage", 0.5, -1.0, 1024.0);
 	
 	/**
-	 * Increases or decreases (negative values) the speed of the player when in water
-	 * The max value will make players zoom through the water much faster than an elytra ever could
-	 * For the sake of maneuverability and server performance it is capped at 0.5. Values >0.1 feel a bit silly already.
-	 * Stacks with dolphins grace and depth strider, albeit the latter has little felt effect at higher speeds
+	 * Controls the speed of the player when in water
+	 * The base value of this attribute is always set dynamically, therefore setting it via a command will have no effect.
+	 * For the sake of maneuverability and server performance it is capped at 1.
+	 * Stacks with dolphins grace and depth strider, albeit the latter has little felt effect at higher speeds.
 	 */
-	public static final EntityAttribute WATER_SPEED = createAttribute("water_speed", 0.0, -1.0, 0.5);
+	public static final EntityAttribute WATER_SPEED = createAttribute("water_speed", 0.5, 0, 1);
 	
 	/**
-	 * Increases or decreases (negative values) the vision of the player when in water by adjusting the fog distance
-	 * A value of -0.5 would make the screen be completely fog, unable to see anything, values > 2 look pretty bad
+	 * Controls the vision of the player when in water by adjusting the fog distance
 	 */
-	public static final EntityAttribute WATER_VISIBILITY = createAttribute("water_visibility", 0.0, -0.48, 2.0);
+	public static final EntityAttribute WATER_VISIBILITY = createAttribute("water_visibility", 96.0, 0, 1024.0);
 	
 	/**
-	 * Increases or decreases (negative values) the speed of the player when in lava
-	 * Values approaching the max value will feel very sluggish. Best to keep it under 0.4
+	 * Controls the speed of the player when in lava
+	 * The base value of this attribute is always set dynamically, therefore setting it via a command will have no effect.
+	 * For the sake of maneuverability and server performance it is capped at 1.
 	 * Negative values will make the player even slower with -1.0 resulting in being almost unable to move
 	 */
-	public static final EntityAttribute LAVA_SPEED = createAttribute("lava_speed", 0.0, -1.0, 0.49);
+	public static final EntityAttribute LAVA_SPEED = createAttribute("lava_speed", 0.5, 0, 1);
 	
 	/**
-	 * Increases or decreases (negative values) the vision of the player when in lava by adjusting the fog distance
+	 * Controls the vision of the player when in lava by adjusting the fog distance
 	 */
-	public static final EntityAttribute LAVA_VISIBILITY = createAttribute("lava_visibility", 0.0, -1024.0, 1024.0);
+	public static final EntityAttribute LAVA_VISIBILITY = createAttribute("lava_visibility", 1.0, 0, 1024.0);
 	
 	@Override
 	public void onInitialize() {
-		Registry.register(Registry.ATTRIBUTE, new Identifier(MOD_ID, "critical_damage_multiplier"), CRITICAL_DAMAGE_MULTIPLIER);
+		Registry.register(Registry.ATTRIBUTE, new Identifier(MOD_ID, "critical_bonus_damage"), CRITICAL_BONUS_DAMAGE);
 		Registry.register(Registry.ATTRIBUTE, new Identifier(MOD_ID, "water_speed"), WATER_SPEED);
 		Registry.register(Registry.ATTRIBUTE, new Identifier(MOD_ID, "water_visibility"), WATER_VISIBILITY);
 		Registry.register(Registry.ATTRIBUTE, new Identifier(MOD_ID, "lava_speed"), LAVA_SPEED);

--- a/src/main/java/de/dafuqs/additionalentityattributes/AdditionalEntityAttributes.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/AdditionalEntityAttributes.java
@@ -11,11 +11,12 @@ public class AdditionalEntityAttributes implements ModInitializer {
 	public static final String MOD_ID = "additionalentityattributes";
 	
 	/**
-	 * for testing, default vanilla commands can be used:
-	 * /attribute Player662 additionalentityattributes:critical_bonuse_damage base get
-	 * /attribute Player583 additionalentityattributes:lava_visibility base set 10
-	 * /attribute Player583 additionalentityattributes:lava_speed base set 0.5
-	 * /attribute Player556 additionalentityattributes:water_speed base set 0.5
+	 * For testing, default vanilla commands can be used:
+	 * /attribute @s additionalentityattributes:critical_bonus_damage modifier add 135e1f1e-755d-4cfe-82da-3648626eeba2 test 1 multiply_base
+	 * /attribute @s additionalentityattributes:lava_visibility modifier add 135e1f1e-755d-4cfe-82da-3648626eeba2 test 10 add
+	 * /attribute @s additionalentityattributes:lava_speed modifier add 135e1f1e-755d-4cfe-82da-3648626eeba2 test -1 multiply
+	 * /attribute @s additionalentityattributes:water_speed modifier add 135e1f1e-755d-4cfe-82da-3648626eeba2 test 0.5 multiply_base
+	 * /attribute @s additionalentityattributes:water_visibility modifier add 135e1f1e-755d-4cfe-82da-3648626eeba2 test -0.5 multiply
 	 */
 	
 	/**

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/BackgroundRendererMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/client/BackgroundRendererMixin.java
@@ -12,12 +12,15 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 @Mixin(BackgroundRenderer.class)
 public abstract class BackgroundRendererMixin {
 	
-	@ModifyConstant(method = "applyFog", constant = @Constant(floatValue = 0.25F, ordinal = 1))
+	@ModifyConstant(method = "applyFog", constant = @Constant(floatValue = 0.25F, ordinal = 0))
 	private static float modifyLavaVisibilityMinWithoutFireResistance(float original, Camera camera) {
 		EntityAttributeInstance lavaVisibilityAttribute = MinecraftClient.getInstance().player.getAttributeInstance(AdditionalEntityAttributes.LAVA_VISIBILITY);
 		if(lavaVisibilityAttribute == null) {
 			return original;
 		} else {
+			if(lavaVisibilityAttribute.getBaseValue() != original) {
+				lavaVisibilityAttribute.setBaseValue(original);
+			}
 			return original - (float) lavaVisibilityAttribute.getValue() * 0.25F;
 		}
 	}
@@ -28,7 +31,10 @@ public abstract class BackgroundRendererMixin {
 		if(lavaVisibilityAttribute == null) {
 			return original;
 		} else {
-			return original + (float) lavaVisibilityAttribute.getValue();
+			if(lavaVisibilityAttribute.getBaseValue() != original) {
+				lavaVisibilityAttribute.setBaseValue(original);
+			}
+			return (float) lavaVisibilityAttribute.getValue();
 		}
 	}
 	
@@ -38,6 +44,9 @@ public abstract class BackgroundRendererMixin {
 		if(lavaVisibilityAttribute == null) {
 			return original;
 		} else {
+			if(lavaVisibilityAttribute.getBaseValue() != original) {
+				lavaVisibilityAttribute.setBaseValue(original);
+			}
 			return original - (float) lavaVisibilityAttribute.getValue();
 		}
 	}
@@ -48,17 +57,23 @@ public abstract class BackgroundRendererMixin {
 		if(lavaVisibilityAttribute == null) {
 			return original;
 		} else {
-			return original + (float) lavaVisibilityAttribute.getValue() * 3.0F;
+			if(lavaVisibilityAttribute.getBaseValue() != original) {
+				lavaVisibilityAttribute.setBaseValue(original);
+			}
+			return (float) lavaVisibilityAttribute.getValue();
 		}
 	}
 	
-	@ModifyConstant(method = "applyFog", constant = @Constant(floatValue = 0.5F, ordinal = 0))
+	@ModifyConstant(method = "applyFog", constant = @Constant(floatValue = 96F, ordinal = 0))
 	private static float modifyWaterVisibility(float original, Camera camera) {
 		EntityAttributeInstance waterVisibilityAttribute = MinecraftClient.getInstance().player.getAttributeInstance(AdditionalEntityAttributes.WATER_VISIBILITY);
 		if(waterVisibilityAttribute == null) {
 			return original;
 		} else {
-			return original + (float) waterVisibilityAttribute.getValue();
+			if(waterVisibilityAttribute.getBaseValue() != original) {
+				waterVisibilityAttribute.setBaseValue(original);
+			}
+			return (float) waterVisibilityAttribute.getValue();
 		}
 	}
 	

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/LivingEntityMixin.java
@@ -22,16 +22,19 @@ public abstract class LivingEntityMixin {
 		info.getReturnValue().add(AdditionalEntityAttributes.WATER_SPEED);
 		info.getReturnValue().add(AdditionalEntityAttributes.LAVA_VISIBILITY);
 		info.getReturnValue().add(AdditionalEntityAttributes.LAVA_SPEED);
-		info.getReturnValue().add(AdditionalEntityAttributes.CRITICAL_DAMAGE_MULTIPLIER);
+		info.getReturnValue().add(AdditionalEntityAttributes.CRITICAL_BONUS_DAMAGE);
 	}
 	
-	@ModifyArg(method = "travel(Lnet/minecraft/util/math/Vec3d;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;updateVelocity(FLnet/minecraft/util/math/Vec3d;)V"))
+	@ModifyArg(method = "travel(Lnet/minecraft/util/math/Vec3d;)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/LivingEntity;updateVelocity(FLnet/minecraft/util/math/Vec3d;)V", ordinal = 0))
 	public float waterSpeed(float original) {
 		EntityAttributeInstance waterSpeed = ((LivingEntity) (Object) this).getAttributeInstance(AdditionalEntityAttributes.WATER_SPEED);
 		if(waterSpeed == null) {
 			return original;
 		} else {
-			return Math.max(0.01F, original + (float) waterSpeed.getValue());
+			if(waterSpeed.getBaseValue() != original) {
+				waterSpeed.setBaseValue(original);
+			}
+			return (float) waterSpeed.getValue();
 		}
 	}
 	
@@ -42,7 +45,10 @@ public abstract class LivingEntityMixin {
 			if(waterSpeed == null) {
 				return original;
 			} else {
-				return Math.max(0.01, original + waterSpeed.getValue());
+				if(waterSpeed.getBaseValue() != original) {
+					waterSpeed.setBaseValue(original);
+				}
+				return waterSpeed.getValue();
 			}
 		} else {
 			return original;
@@ -56,7 +62,10 @@ public abstract class LivingEntityMixin {
 		if(waterSpeed == null) {
 			return original;
 		} else {
-			return Math.min(-0.01, original - waterSpeed.getValue());
+			if(waterSpeed.getBaseValue() != -original) {
+				waterSpeed.setBaseValue(-original);
+			}
+			return -waterSpeed.getValue();
 		}
 	}
 	
@@ -66,7 +75,10 @@ public abstract class LivingEntityMixin {
 		if(lavaSpeed == null) {
 			return original;
 		} else {
-			return original + lavaSpeed.getValue();
+			if(lavaSpeed.getBaseValue() != original) {
+				lavaSpeed.setBaseValue(original);
+			}
+			return lavaSpeed.getValue();
 		}
 	}
 }

--- a/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/PlayerEntityMixin.java
+++ b/src/main/java/de/dafuqs/additionalentityattributes/mixin/common/PlayerEntityMixin.java
@@ -12,15 +12,15 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 public class PlayerEntityMixin {
 	
 	/**
-	 * By default, the additional crit damage is a flat *1.5
+	 * By default, the additional crit damage is a 50% bonus
 	 */
 	@ModifyConstant(method = "attack(Lnet/minecraft/entity/Entity;)V", constant = @Constant(floatValue = 1.5F))
 	public float applyCriticalDamageMultiplierAttribute(float original) {
-		EntityAttributeInstance criticalDamageMultiplier = ((LivingEntity) (Object) this).getAttributeInstance(AdditionalEntityAttributes.CRITICAL_DAMAGE_MULTIPLIER);
+		EntityAttributeInstance criticalDamageMultiplier = ((LivingEntity) (Object) this).getAttributeInstance(AdditionalEntityAttributes.CRITICAL_BONUS_DAMAGE);
 		if(criticalDamageMultiplier == null) {
 			return original;
 		} else {
-			return original + (float) criticalDamageMultiplier.getValue();
+			return 1 + (float) criticalDamageMultiplier.getValue();
 		}
 	}
 

--- a/src/main/resources/assets/additionalentityattributes/lang/en_us.json
+++ b/src/main/resources/assets/additionalentityattributes/lang/en_us.json
@@ -1,0 +1,7 @@
+{
+  "attribute.name.generic.additionalentityattributes.water_speed": "Movement Speed in Water",
+  "attribute.name.generic.additionalentityattributes.lava_speed": "Movement Speed in Lava",
+  "attribute.name.generic.additionalentityattributes.critical_bonus_damage": "Critical Strike Bonus Damage",
+  "attribute.name.generic.additionalentityattributes.water_visibility": "Vision in Water",
+  "attribute.name.generic.additionalentityattributes.lava_visibility": "Vision in Lava"
+}


### PR DESCRIPTION
As discussed on Discord:

> The attributes currently are basically "additional values", as in the base is 0, and the resulting attribute value is added onto the original. In my opinion, it should treat the original value of the mixin as the "current base value" of the attribute. This is beneficial because otherwise the attributes can only be used to add or subtract, while attribute modifiers usually allow `MULTIPLY_TOTAL` and `MULTIPLY_BASE` operations as well. Those operations in the current implementation only apply to the "bonus" value granted by the attribute. A `MULTIPLY_TOTAL` modifier to reduce the water vision by 50% currently does nothing.

This PR changes it, so all attributes now have a base value, and their resulting value is used for the specific property. This allows multiplicative modifiers to affect the value.
In the case of water and lava speed, as well as water and lava visibility, the base value of the attribute is set dynamically, based on the mixin where the attribute applies. This is for example relevant in the case of lava visibility, where the vanilla ("base") value changes depending on whether a fire resistance potion is active or not.
The drawback is that the base value of the attributes can not be modified by commands, but I'd consider that an edge case which is not used by most of the player base.

In the case of the critical damage multiplier, the attribute was changed to apply to only the bonus damage dealt by critical strikes, and not the whole multiplier. This allows e.g. an easy creation of a modifier which removes all bonus damage from crits completely, which would be impossible if the attribute would affect the whole multiplier. As a result of this, and in accordance with the changes above to make the values modifiable by multipliers, the base value of this attribute has been set to `0.5`. Additionally, the name and ID have been changed to "critical bonus damage" to better reflect the attributes new functionality.

I also took the liberty of adding an `en_us` language file in order to provide a localization in case users add modifiers for these attributes onto items.